### PR TITLE
Rewrite README for accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,126 @@
-The `StringWeaver` package exposes a custom high-performance builder for `string`s with a mutable, directly accessible buffer and a versatile API for manipulating the contents.
+# StringWeaver
 
-> **Note:** `StringWeaver` is _not_ a drop-in replacement for `StringBuilder`. Its single contiguous buffer enables `Span<char>` access and in-place regex operations, but growing copies the entire buffer. See the [wiki Examples page](wiki/Examples.md) for guidance on when to choose `StringWeaver` vs `StringBuilder`.
+A mutable string builder that lets you chain replacements, regex transforms, and trims in-place — without allocating a new string at every step.
 
-# Consumption
+> **Note:** `StringWeaver` is _not_ a drop-in replacement for `StringBuilder`. Its single contiguous buffer enables `Span<char>` access and in-place regex operations, but growing copies the entire buffer. See the [wiki Examples page](wiki/Examples.md) for guidance on when to choose one over the other.
 
-The assembly multi-targets `netstandard2.0` and several newer .NETs to support performance-focused APIs introduced in later versions:
+## Why?
 
-* Core functionality is exposed in the `netstandard2.0` compilation, meaning any conforming project platform can use it.
-* A dependency on `PCRE.NET` is used across **all** targets to facilitate regex operations on `StringWeaver` without requiring allocations for match details. This is the primary regex engine.
-* Several quality-of-life APIs are also introduced in their respective compilations, such as support for `ISpanFormattable` on `>= net6.0`.
-* For `>= net7.0`, for the `Replace*` and `EnumerateIndicesOf*` methods that take a `PcreRegex`, analogous methods that take a `Regex` instance and utilize the Span-based APIs introduced in `System.Text.RegularExpressions` are also exposed.
-* `net8.0` introduced many `Span`-based APIs throughout the entire .NET ecosystem, allowing streamlined code paths on `>= net8.0`.
+Every `string.Replace` or `Regex.Replace` allocates a brand-new string. Chain a few together in a cleanup pipeline and you're creating dozens of throwaway copies:
 
-Neither `PCRE.NET` nor `System.Text.RegularExpressions` expose APIs that produce allocating match-details objects from a `Span` input. As a result, the traditional `MatchEvaluator` delegate pattern is not supported. Instead, `StringWeaver` exposes the `StringWeaverWriter` delegate (`void(Span<char> buffer, ReadOnlySpan<char> match)`) together with a `bufferSize` parameter, which allows dynamically generating replacement content with zero allocations.
+```csharp
+// Classic approach — each call allocates a new string
+string result = input
+    .Replace("\r\n", "\n")
+    .Replace("\t", " ")
+    .Trim();
+result = Regex.Replace(result, @"\s{2,}", " ");
+result = Regex.Replace(result, @"<[^>]+>", "");
+```
 
-# Variants
+StringWeaver performs all of these operations on **one buffer**. You get a single allocation at the end, when you call `ToString()`:
 
-For some usage examples, refer to the [wiki Examples page](wiki/Examples.md).
+```csharp
+using SW = StringWeaver.StringWeaver;
 
-## General purpose
+var sw = new SW(input);       // one buffer, seeded with input
+sw.ReplaceAll("\r\n", "\n");  // in-place
+sw.ReplaceAll("\t", " ");     // in-place
+sw.Trim();                    // in-place
+sw.ReplaceAll(new PcreRegex(@"\s{2,}"), " ");
+sw.ReplaceAll(new PcreRegex(@"<[^>]+>"), "");
+string result = sw.ToString(); // single allocation
+```
 
-Namespace: `global::StringWeaver`
+This matters when you're cleaning user input, sanitizing HTML, normalizing log lines, or running any pipeline where text passes through multiple transformation steps.
 
-* `StringWeaver`: Default and most versatile implementation. Offers the full API surface and sources its backing buffers by `new`'ing and resizing `char[]`s on demand.
-  * The default `StringWeaver` should be the first choice for the ordinary consumer. Where profiling shows that a different implementation would be more beneficial, consider the alternatives described below.
-* `UnsafeStringWeaver`: Implements a `StringWeaver` that sources its backing buffers from unmanaged instead of managed memory. This has the benefit of not causing any GC pressure while exposing exactly the same APIs as the default `StringWeaver`.
-  * Consider using this if you frequently create `StringWeaver`s with capacities near `int.MaxValue` or instances which are very long-lived.
-  * &#x26A0; `UnsafeStringWeaver` implements `IDisposable` (`StringWeaver` does not). Not disposing of instances of `UnsafeStringWeaver` is a memory leak.
+## Quick start
 
-## Specialized
+```
+dotnet add package StringWeaver
+```
 
-Namespace: `global::StringWeaver.Specialized`
+```csharp
+using SW = StringWeaver.StringWeaver;
 
-* `PooledStringWeaver`: Implements a `StringWeaver` that sources its backing buffers from `ArrayPool<char>.Shared` (or your own passed implementation of `ArrayPool<char>`). This allows keeping GC pressure low while still using managed memory.
-  * Consider using this if you frequently create and dispose of `StringWeaver`s with non-trivial capacities (e.g. a few dozen kB or more).
-  * &#x26A0; `PooledStringWeaver` implements `IDisposable` (`StringWeaver` does not). Not disposing of instances of `PooledStringWeaver` causes the buffer backing it to be lost to the pool, which is a memory leak and degrades performance of every other user of that `ArrayPool<char>` in your application.
-* `WrappingStringWeaver`: A truly zero-allocation wrapper for existing buffers that otherwise offer the full capabilities of the base `StringWeaver` implementation.
-  * Use this any time you already have some memory you want to treat as a `char` buffer and want to avoid copying at all costs.
-  * &#x26A0; `WrappingStringWeaver` only pins memory for you when specifically asked to do so (and only when given a `char[]` or `Memory<char>`). Given a `Span<char>` or a pointer (whether managed or unmanaged), it is the caller's responsibility to ensure the memory remains valid and accessible for the lifetime of the `WrappingStringWeaver` instance. Changing the contents of the memory outside of the `WrappingStringWeaver` instance should be done with caution but is generally safe (under the same constraints as the default `StringWeaver` implementation, e.g. `EnumerateIndicesOf` `ref struct`s ensuring the buffer wasn't modified during enumeration). See this variant's wiki page for more details and usage examples.
-  * While all constructors take buffers or pointers typed as `char` in some form, you can reinterpret any memory as `char` and use it with `WrappingStringWeaver`. Pinned memory reinterpreted using `Unsafe.As<TFrom, TTo>(ref TFrom)` is a good example of this.
-  * &#x26A0; `WrappingStringWeaver` implements `IDisposable` (`StringWeaver` does not). If you used one of the overloads that specify that the memory should be pinned, not disposing of the instance is a memory leak.
+// Create from a string, span, byte[], or another StringWeaver
+var sw = new SW("Hello, World!");
 
-# Inheritance
+// Mutate in-place
+sw.ReplaceAll("World", "NuGet");
+sw.Append(" 🎉");
+sw.Trim('!');
 
-`StringWeaver` itself is not `sealed` because `UnsafeStringWeaver` inherits from it. As such, inheritance from `StringWeaver` is allowed for external types as well. There are only a select few members you must override to make your implementation function correctly, everything else (functionality-wise) is handled for you (and not virtual, for that matter):
+// Read the result
+string final = sw.ToString();
+// Or access the buffer directly
+ReadOnlySpan<char> span = sw.Span;
+```
 
-* `Memory<char> FullMemory`: Gets a `Memory<char>` instance over the entire backing storage (NOT just the used portion).
-* `void GrowCore(int requiredCapacity)`: WITHOUT checking whether it is required, expands the backing storage to at least the specified capacity (those checks are done for you before this `virtual` method is ever called).
-* &#x26A0; `StringWeaver.ToString` (the base version) is `sealed override`.
-* `IBufferWriter<char>` implementations as well as `Stream` and `TextWriter` support through wrappers are both handled internally as well. Do not re-implement any of those.
+The full API includes `Append`, `Replace`, `ReplaceAll`, `Remove`, `Trim`, `TrimStart`, `TrimEnd`, `TrimSequence`, `Clear`, `Drain`, indexer access via `Index`/`Range`, and `IndexOf`/`EnumerateIndicesOf` for searching — all operating in-place on the same buffer. Regex overloads accept either `PcreRegex` or `System.Text.RegularExpressions.Regex` (on `>= net7.0`).
 
-Adding functionality on top of anything already handled for you is straightforward. All the base functionality can be used to compose your own methods or just use `(Full)Memory`/`(Full)Span` to access the backing storage directly. `Start` and `End` control which portion of the buffer is considered "used"; `Length` is computed from these.
+For more examples, see the [wiki Examples page](wiki/Examples.md).
 
-&#x26A0; The above statement is true for disposal. As mentioned, `StringWeaver` does _not_ implement `IDisposable`, so derived types must do so themselves if they require it. Ensure cleanup for your own types is sound.
+## Regex without allocating match objects
 
-## &#x26A0; v2.0.0+ Breaking Changes
+Neither `PCRE.NET` nor `System.Text.RegularExpressions` expose APIs that produce allocating match-detail objects from a `Span` input. The traditional `MatchEvaluator` delegate pattern is therefore not supported. Instead, StringWeaver exposes the `StringWeaverWriter` delegate (`void(Span<char> buffer, ReadOnlySpan<char> match)`) together with a `bufferSize` parameter, which allows dynamically generating replacement content with zero allocations.
 
-v2.0.0 saw the introduction of breaking changes to further reduce allocations for specific scenarios. If you aren't deriving from `StringWeaver`, you will very likely not be affected by most of these changes.
+## Variants
 
-* `protected int Start { get; set; }` and `protected int End { get; set; }`: These properties delimit the used portion of the buffer. This allows derived types to implement functionality that would otherwise require shifting data around in the backing storage. It is discouraged for custom derived types to modify this directly. The methods `StringWeaver` exposes are well-behaved with respect to this property, if its value is sane at call time.
-* `public int Length { get; }`: This property no longer has a setter. It is now a computed property using the new property `StringWeaver.End`.
-* `protected internal virtual Memory<char> FullMemory { get; }`: There has been no API change for this property, but the details of exactly what it is expected to return very much has. It must encompass the entirety of the backing memory of the current instance, regardless of the values of `StringWeaver.Start` and `StringWeaver.End`. Before this, this expecation wasn't very explicit; trimming or similar operations kept the used portion of the backing memory aligned to index `0` in the `Memory<char>` returned by this property. This is no longer the case to reduce allocations where possible; however, the above change was made to facilitate this.
-* `protected void EnsureZeroAligned()`: Aligns the used portion to index `0` in the backing storage for you using `StringWeaver.Start` and `StringWeaver.End`.
-* `protected void ValidateRange(int index, int length)`: Validates a range against the used portion of the buffer, throwing an `ArgumentOutOfRangeException` for you if it is not entirely within bounds.
-* `protected virtual void GrowCore(int requiredCapacity)`: Instead of `protected virtual void Grow(int requiredCapacity)`, you now override `GrowCore`. Because increasing `StringWeaver.Start` values effectively reduce the available capacity, a new branch was added that attempts to satisfy the capacity requirement without actually needing to allocate using `EnsureZeroAligned`.
-* `protected virtual void ClearCore()`: Introduced to support derived `StringWeaver` types that need to do additional cleanup when `Clear` is called or where clearing is not just setting `StringWeaver.Start` and `StringWeaver.End` to `0`.
+Start with the default `StringWeaver`. Switch to an alternative only when profiling shows it would help.
 
-On a less... annoying note, `void ReplaceAll(ReadOnlySpan<char>, ReadOnlySpan<char>)` (and the overloads taking an `int index` and `int length`, as well as several methods that delegate to this one) had a path optimized that allocated temporary storage for the replacement process. This memory is now sourced either from a `stackalloc` or from native memory.
+| Type | Namespace | Backing memory | `IDisposable` | When to use |
+|---|---|---|---|---|
+| `StringWeaver` | `StringWeaver` | `char[]` (managed) | No | Default choice. |
+| `UnsafeStringWeaver` | `StringWeaver` | Unmanaged (`Marshal`) | **Yes** | Very large or very long-lived buffers; avoids GC pressure entirely. |
+| `PooledStringWeaver` | `StringWeaver.Specialized` | `ArrayPool<char>.Shared` | **Yes** | Frequent create/dispose cycles with non-trivial capacities (dozens of kB+). |
+| `WrappingStringWeaver` | `StringWeaver.Specialized` | Caller-provided buffer | **Yes** (if pinned) | You already own the memory and want zero-copy access to the full API. |
 
-# Global configuration
+⚠️ Variants marked `IDisposable` **must** be disposed. Failing to do so leaks memory (or, for `PooledStringWeaver`, degrades pool performance app-wide). `WrappingStringWeaver` given a `Span<char>` or pointer requires the caller to keep the memory valid for the wrapper's lifetime.
 
-The `static class StringWeaverConfiguration` exposes global configuration options for all `StringWeaver` variants where applicable. The options are usually strongly-typed and implemented in a thread-safe manner, however, altering options while the affected variants are in use will very likely lead to undefined behavior. I recommend very carefully thinking about what you're changing, why you're doing it and if it's really a good idea, then setting them on application startup and never touching the entire class again.
+## Framework support
 
-# Contribution
+The assembly multi-targets `netstandard2.0`, `net6.0`, `net7.0`, and `net8.0`:
 
-Opening issues and submitting PRs are welcome. All changes must be appropriately covered by tests. Tests run exclusively under `net10.0`.
+* **`netstandard2.0`** — full core functionality; works on any conforming platform.
+* **`>= net6.0`** — quality-of-life additions such as `ISpanFormattable` support.
+* **`>= net7.0`** — `Replace*` and `EnumerateIndicesOf*` overloads accepting `System.Text.RegularExpressions.Regex` (span-based API).
+* **`>= net8.0`** — streamlined code paths using the `Span`-based APIs introduced across the .NET ecosystem.
 
-Support for `netstandard2.0` must always be maintained. If possible, new functionality should be added to all target frameworks. New dependencies may be introduced after I vet the decision to do so.
+A dependency on [`PCRE.NET`](https://github.com/ltrzesniewski/pcre-net) is used across all targets as the primary regex engine.
 
-Or get in touch on Discord `@eyeoftheenemy`
+## Inheritance
+
+`StringWeaver` is not `sealed`; you can derive from it. Override these two members to provide your own backing storage:
+
+* `Memory<char> FullMemory` — the **entire** backing memory, not just the used portion.
+* `void GrowCore(int requiredCapacity)` — expand storage to at least the given capacity (pre-validated by the base class).
+
+Everything else — `IBufferWriter<char>`, `Stream`/`TextWriter` wrappers, all public mutation methods — is handled for you. `Start`, `End`, and `Length` control which portion of the buffer is considered "used". `ToString()` is `sealed override`.
+
+⚠️ The base `StringWeaver` does _not_ implement `IDisposable`. Derived types that manage their own resources must implement it themselves.
+
+<details>
+<summary>⚠️ v2.0.0+ breaking changes (click to expand)</summary>
+
+These changes further reduce allocations. If you are **not** deriving from `StringWeaver`, you are very likely unaffected.
+
+* `Start` / `End` are now `protected int` properties that delimit the used portion of the buffer. `Length` is computed from `End - Start` and no longer has a setter.
+* `FullMemory` must return the **entirety** of the backing memory regardless of `Start`/`End`. Trimming no longer keeps data zero-aligned.
+* `Grow(int)` was renamed to `GrowCore(int)`. A new branch attempts to satisfy capacity requirements via `EnsureZeroAligned()` before allocating.
+* New helpers: `EnsureZeroAligned()`, `ValidateRange(int, int)`, `ClearCore()`.
+* `ReplaceAll(ReadOnlySpan<char>, ReadOnlySpan<char>)` (and related overloads) no longer allocates temporary managed storage; it uses `stackalloc` or native memory instead.
+
+</details>
+
+## Global configuration
+
+`StringWeaverConfiguration` exposes global, thread-safe options for all variants. Set them once on application startup — changing them while instances are in use leads to undefined behavior.
+
+## Contribution
+
+Issues and PRs are welcome. All changes must be covered by tests. Tests run exclusively under `net10.0`.
+
+`netstandard2.0` support must always be maintained. New functionality should target all frameworks when possible. New dependencies require maintainer approval.
+
+Discord: `@eyeoftheenemy`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A mutable string builder that lets you chain replacements, regex transforms, and
 Every `string.Replace` or `Regex.Replace` allocates a brand-new string. Chain a few together in a cleanup pipeline and you're creating dozens of throwaway copies:
 
 ```csharp
+using System.Text.RegularExpressions;
+
 // Classic approach — each call allocates a new string
 string result = input
     .Replace("\r\n", "\n")
@@ -18,9 +20,10 @@ result = Regex.Replace(result, @"\s{2,}", " ");
 result = Regex.Replace(result, @"<[^>]+>", "");
 ```
 
-StringWeaver performs all of these operations on **one buffer**. You get a single allocation at the end, when you call `ToString()`:
+StringWeaver performs all of these operations on **one buffer**. No intermediate string is created between steps — the only `string` allocation is the one `ToString()` returns:
 
 ```csharp
+using PCRE;
 using SW = StringWeaver.StringWeaver;
 
 var sw = new SW(input);       // one buffer, seeded with input
@@ -29,7 +32,7 @@ sw.ReplaceAll("\t", " ");     // in-place
 sw.Trim();                    // in-place
 sw.ReplaceAll(new PcreRegex(@"\s{2,}"), " ");
 sw.ReplaceAll(new PcreRegex(@"<[^>]+>"), "");
-string result = sw.ToString(); // single allocation
+string result = sw.ToString(); // the only string allocation
 ```
 
 This matters when you're cleaning user input, sanitizing HTML, normalizing log lines, or running any pipeline where text passes through multiple transformation steps.
@@ -74,7 +77,7 @@ Start with the default `StringWeaver`. Switch to an alternative only when profil
 | `StringWeaver` | `StringWeaver` | `char[]` (managed) | No | Default choice. |
 | `UnsafeStringWeaver` | `StringWeaver` | Unmanaged (`Marshal`) | **Yes** | Very large or very long-lived buffers; avoids GC pressure entirely. |
 | `PooledStringWeaver` | `StringWeaver.Specialized` | `ArrayPool<char>.Shared` | **Yes** | Frequent create/dispose cycles with non-trivial capacities (dozens of kB+). |
-| `WrappingStringWeaver` | `StringWeaver.Specialized` | Caller-provided buffer | **Yes** (if pinned) | You already own the memory and want zero-copy access to the full API. |
+| `WrappingStringWeaver` | `StringWeaver.Specialized` | Caller-provided buffer | **Yes** | You already own the memory and want zero-copy access to the full API. Disposing is required when constructed with pinned memory; always recommended otherwise. |
 
 ⚠️ Variants marked `IDisposable` **must** be disposed. Failing to do so leaks memory (or, for `PooledStringWeaver`, degrades pool performance app-wide). `WrappingStringWeaver` given a `Span<char>` or pointer requires the caller to keep the memory valid for the wrapper's lifetime.
 


### PR DESCRIPTION
## Summary

- The existing README was written for experts already familiar with the library's internals. It buried the core value proposition (in-place text cleanup pipelines) under framework-targeting details, inheritance docs, and breaking-change notes.
- Added a **Why?** section at the top with a concrete before/after showing the classic `string.Replace`/`Regex.Replace` chain problem vs. StringWeaver's single-buffer approach — directly addressing feedback that beginners couldn't quickly understand the point of the library.
- Added a **Quick start** block (`dotnet add package` + minimal usage) so readers have runnable code within the first scroll.
- Condensed the four variants into a comparison table; collapsed v2.0.0 breaking changes behind a `<details>` element (still present for library extenders, invisible to everyone else).
- All technical facts from the original are preserved. No new claims added.